### PR TITLE
Add guard to onMessage, force any type to sting.

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -1,4 +1,3 @@
-/* eslint-disable linebreak-style */
 import { programs } from '../programs/programs.js';
 import { Et3400 } from './modules/Et3400.js';
 import { ExamineController } from '../examinables/ExamineController.js';

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -1,3 +1,4 @@
+/* eslint-disable linebreak-style */
 import { programs } from '../programs/programs.js';
 import { Et3400 } from './modules/Et3400.js';
 import { ExamineController } from '../examinables/ExamineController.js';
@@ -234,8 +235,11 @@ function doPopout() {
  * Handles the message event sent from the popout window
  * @param {MessageEvent} event The event object sent from the popout window
  */
-function onMessage(event) {
-  const [action, operand] = event.data.split(':');
+function onMessage({data}) {
+  if (typeof data !== 'string') {
+    data = String(data);
+  }
+  const [action, operand] = data.split(':');
   if (action === 'releaseKey') {
     globalThis.et3400.releaseKey(operand);
   } else if (action === 'pressKey') {


### PR DESCRIPTION
Resolves #31 

Adds a guard to onMessage that coerces event.data to a string.  This is to prevent errors from being thrown by the subsequent call to split().